### PR TITLE
axon: Fix pcap file termination issue.

### DIFF
--- a/axon/apps/console.py
+++ b/axon/apps/console.py
@@ -91,6 +91,14 @@ class Console(BaseApp):
                                 close_fds=True, preexec_fn=os.setsid,
                                 bufsize=-1)
 
+    def _ctrl_c(self, proc, timeout=1):
+        """
+        """
+        proc.send_signal(signal.SIGINT)
+        # For child processes, you need to wait for some time after sending
+        # SIGINT signal : https://bugs.python.org/issue25942
+        proc.wait(timeout)
+
     def _kill_subprocess(self, proc, close_fds=False):
         """
         Kills a subprocess represented by handle 'proc'.

--- a/axon/apps/tcpdump.py
+++ b/axon/apps/tcpdump.py
@@ -63,6 +63,7 @@ class TCPDump(console.Console):
         ident = self._get_identifier(dst_file)
         proc = self._get_pcap_handle(ident)
         if proc:
+            self._ctrl_c(proc)
             self._kill_subprocess(proc)
             self._pcap_handles.pop(ident)
             msg = ("Stopped Packet capture for %s. Result is available"


### PR DESCRIPTION
Change here
    - sends CTRL C signal first to child process running tcpdump.
    - waits for a fixed time as required by issue
      https://bugs.python.org/issue25942
    - At last kills the process.

Previously due to abrupt killing of child process (without wait) ,
tcpdump was not able to analyze all the file and tcpdump -r <pcap_file>
used to give error. With the change, all the file is processed
correctly.

Signed-off-by: Vipin Sharma <sh.vipin@gmail.com>